### PR TITLE
AES256 is now replaced by a new AES-SIV implementation for determinis…

### DIFF
--- a/Pandatech.Crypto.sln.DotSettings
+++ b/Pandatech.Crypto.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=aead/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=decryptor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pandatech/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Pandatech.Crypto/Extensions/WebAppExtensions.cs
+++ b/src/Pandatech.Crypto/Extensions/WebAppExtensions.cs
@@ -8,6 +8,7 @@ public static class WebAppExtensions
    public static WebApplicationBuilder AddAes256Key(this WebApplicationBuilder builder, string aesKey)
    {
       Aes256.RegisterKey(aesKey);
+      Aes256Siv.RegisterKey(aesKey);
       return builder;
    }
 

--- a/src/Pandatech.Crypto/Helpers/Aes256.cs
+++ b/src/Pandatech.Crypto/Helpers/Aes256.cs
@@ -3,6 +3,8 @@ using System.Security.Cryptography;
 
 namespace Pandatech.Crypto.Helpers;
 
+[Obsolete(
+   "This class is deprecated due to security concerns. Use Aes256Siv instead. For migration purposes we let this obsolete class with AesMigration class to make migration easier. Later this class will be removed.")]
 public static class Aes256
 {
    private const int KeySize = 256;

--- a/src/Pandatech.Crypto/Helpers/Aes256Siv.cs
+++ b/src/Pandatech.Crypto/Helpers/Aes256Siv.cs
@@ -1,0 +1,195 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Macs;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Utilities;
+
+namespace Pandatech.Crypto.Helpers;
+
+public static class Aes256Siv
+{
+   private static string? GlobalKey { get; set; }
+
+   internal static void RegisterKey(string key)
+   {
+      ValidateKey(key);
+      GlobalKey = key;
+   }
+
+   public static byte[] Encrypt(string plaintext, string? key = null)
+   {
+      var bytes = Encoding.UTF8.GetBytes(plaintext);
+      return Encrypt(bytes, key);
+   }
+
+   public static byte[] Encrypt(byte[] plaintext, string? key = null)
+   {
+      if (plaintext.Length == 0)
+      {
+         return [];
+      }
+
+      var keyBytes = GetKeyBytes(key);
+      var macKey = keyBytes[..16];
+      var encKey = keyBytes[16..];
+
+      var siv = ComputeS2V(macKey, plaintext);
+      var cipher = AesCtr(encKey, siv, plaintext);
+      return Arrays.Concatenate(siv, cipher);
+   }
+
+   public static void Encrypt(Stream input, Stream output, string? key = null)
+   {
+      ArgumentNullException.ThrowIfNull(input);
+      ArgumentNullException.ThrowIfNull(output);
+
+      using var ms = new MemoryStream();
+      input.CopyTo(ms);
+      var encrypted = Encrypt(ms.ToArray(), key);
+      output.Write(encrypted, 0, encrypted.Length);
+   }
+
+   public static string Decrypt(byte[] ciphertext, string? key = null)
+   {
+      var plain = DecryptToBytes(ciphertext, key);
+      return Encoding.UTF8.GetString(plain);
+   }
+
+   public static byte[] DecryptToBytes(byte[] ciphertext, string? key = null)
+   {
+      var keyBytes = GetKeyBytes(key);
+
+      switch (ciphertext.Length)
+      {
+         case 0:
+            return [];
+         case < 16:
+            throw new ArgumentException("At least 16 bytes are required for the SIV.");
+      }
+
+      var macKey = keyBytes[..16];
+      var encKey = keyBytes[16..];
+
+      var siv = ciphertext[..16];
+      var encrypted = ciphertext[16..];
+
+      var plain = AesCtr(encKey, siv, encrypted);
+      var expectedSiv = ComputeS2V(macKey, plain);
+
+      if (!CryptographicOperations.FixedTimeEquals(siv, expectedSiv))
+         throw new CryptographicException("Invalid SIV / authentication tag.");
+
+      return plain;
+   }
+
+   public static void Decrypt(Stream input, Stream output, string? key = null)
+   {
+      ArgumentNullException.ThrowIfNull(input);
+      ArgumentNullException.ThrowIfNull(output);
+
+      using var ms = new MemoryStream();
+      input.CopyTo(ms);
+      var decrypted = DecryptToBytes(ms.ToArray(), key);
+      output.Write(decrypted, 0, decrypted.Length);
+   }
+
+   private static byte[] ComputeS2V(byte[] macKey, byte[] data)
+   {
+      var cmac = new CMac(new AesEngine());
+      cmac.Init(new KeyParameter(macKey));
+      var D = CmacHash(cmac, new byte[16]);
+
+      if (data.Length >= 16)
+      {
+         var block = new byte[16];
+         Array.Copy(data, data.Length - 16, block, 0, 16);
+         for (var i = 0; i < 16; i++)
+            block[i] ^= D[i];
+         return CmacHash(cmac, block);
+      }
+      else
+      {
+         D = DoubleBlock(D);
+         var block = Pad(data);
+         for (var i = 0; i < 16; i++)
+            block[i] ^= D[i];
+         return CmacHash(cmac, block);
+      }
+   }
+
+   private static byte[] AesCtr(byte[] key, byte[] iv, byte[] input)
+   {
+      var cipher = new BufferedBlockCipher(new SicBlockCipher(new AesEngine()));
+      cipher.Init(true, new ParametersWithIV(new KeyParameter(key), iv));
+      return cipher.DoFinal(input);
+   }
+
+   private static byte[] CmacHash(IMac cmac, byte[] input)
+   {
+      cmac.Reset();
+      cmac.BlockUpdate(input, 0, input.Length);
+      var output = new byte[cmac.GetMacSize()];
+      cmac.DoFinal(output, 0);
+      return output;
+   }
+
+   private static byte[] Pad(byte[] input)
+   {
+      var padded = new byte[16];
+      Array.Copy(input, padded, input.Length);
+      padded[input.Length] = 0x80;
+      return padded;
+   }
+
+   private static byte[] DoubleBlock(byte[] block)
+   {
+      var output = new byte[16];
+      var carry = 0;
+      for (var i = 15; i >= 0; i--)
+      {
+         var val = (block[i] & 0xFF) << 1;
+         val |= carry;
+         output[i] = (byte)(val & 0xFF);
+         carry = (val >> 8) & 1;
+      }
+
+      if ((block[0] & 0x80) != 0)
+         output[15] ^= 0x87;
+      return output;
+   }
+
+   private static byte[] GetKeyBytes(string? overrideKey)
+   {
+      if (!string.IsNullOrEmpty(overrideKey))
+      {
+         ValidateKey(overrideKey);
+         return Convert.FromBase64String(overrideKey);
+      }
+
+      if (GlobalKey is null)
+      {
+         throw new InvalidOperationException("AES256 Key not configured. Call RegisterKey(...) or provide a key.");
+      }
+
+      return Convert.FromBase64String(GlobalKey);
+   }
+
+   private static void ValidateKey([NotNull] string? key)
+   {
+      if (string.IsNullOrWhiteSpace(key) || !IsBase64String(key))
+         throw new ArgumentException("Key must be valid Base64.");
+      if (Convert.FromBase64String(key)
+                 .Length != 32)
+         throw new ArgumentException("Key must be 32 bytes (256 bits).");
+   }
+
+   private static bool IsBase64String(string input)
+   {
+      var buffer = new Span<byte>(new byte[input.Length]);
+      return Convert.TryFromBase64String(input, buffer, out _);
+   }
+}

--- a/src/Pandatech.Crypto/Helpers/AesMigration.cs
+++ b/src/Pandatech.Crypto/Helpers/AesMigration.cs
@@ -1,0 +1,69 @@
+﻿namespace Pandatech.Crypto.Helpers;
+
+[Obsolete("This class is temporary for migration purposes from AES256 to AES256SIV. It will be removed in the future.")]
+public static class AesMigration
+{
+   public static List<byte[]?> MigrateFromOldHashedNullable(IEnumerable<byte[]?> oldCiphertexts)
+   {
+      return oldCiphertexts.Select(MigrateFromOldHashedNullable)
+                           .ToList();
+   }
+
+   public static List<byte[]> MigrateFromOldHashed(IEnumerable<byte[]> oldCiphertexts)
+   {
+      return oldCiphertexts.Select(MigrateFromOldHashed)
+                           .ToList();
+   }
+
+   public static List<byte[]?> MigrateFromOldNonHashedNullable(IEnumerable<byte[]?> oldCiphertexts)
+   {
+      return oldCiphertexts.Select(MigrateFromOldNonHashedNullable)
+                           .ToList();
+   }
+
+   public static List<byte[]> MigrateFromOldNonHashed(IEnumerable<byte[]> oldCiphertexts)
+   {
+      return oldCiphertexts.Select(MigrateFromOldNonHashed)
+                           .ToList();
+   }
+
+
+   public static byte[]? MigrateFromOldHashedNullable(byte[]? oldCiphertext)
+   {
+      if (oldCiphertext == null)
+      {
+         return null;
+      }
+
+      var plaintext = Aes256.Decrypt(oldCiphertext);
+
+      return Aes256Siv.Encrypt(plaintext);
+   }
+
+   public static byte[] MigrateFromOldHashed(byte[] oldCiphertext)
+   {
+      var plaintext = Aes256.Decrypt(oldCiphertext);
+
+      return Aes256Siv.Encrypt(plaintext);
+   }
+
+   public static byte[]? MigrateFromOldNonHashedNullable(byte[]? oldCiphertext)
+   {
+      if (oldCiphertext == null)
+      {
+         return null;
+      }
+
+      var plaintext = Aes256.DecryptWithoutHash(oldCiphertext);
+
+      return Aes256Siv.Encrypt(plaintext);
+   }
+
+
+   public static byte[] MigrateFromOldNonHashed(byte[] oldCiphertext)
+   {
+      var plaintext = Aes256.DecryptWithoutHash(oldCiphertext);
+
+      return Aes256Siv.Encrypt(plaintext);
+   }
+}

--- a/src/Pandatech.Crypto/Pandatech.Crypto.csproj
+++ b/src/Pandatech.Crypto/Pandatech.Crypto.csproj
@@ -8,12 +8,12 @@
         <Copyright>MIT</Copyright>
         <PackageIcon>pandatech.png</PackageIcon>
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
-        <Version>4.1.2</Version>
+        <Version>5.0.0</Version>
         <Title>Pandatech.Crypto</Title>
         <PackageTags>Pandatech, library, encryption, hash, algorythms, security</PackageTags>
         <Description>PandaTech.Crypto is a .NET library simplifying common cryptograhic functions.</Description>
         <RepositoryUrl>https://github.com/PandaTechAM/be-lib-pandatech-crypto</RepositoryUrl>
-        <PackageReleaseNotes>Nuget updates</PackageReleaseNotes>
+        <PackageReleaseNotes>AES256 is now replaced by a new AES-SIV implementation for deterministic and authenticated encryption. The old Aes256 class is deprecated due to security concerns, and the new AesMigration class helps convert existing Aes256 ciphertext to the AES-SIV format. The readme has been updated with code samples and usage recommendations.</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -24,8 +24,8 @@
     <ItemGroup>
         <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1"/>
         <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-        <PackageReference Include="Pandatech.RegexBox" Version="3.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4"/>
+        <PackageReference Include="Pandatech.RegexBox" Version="3.0.1"/>
     </ItemGroup>
 
 </Project>

--- a/test/Pandatech.Crypto.Tests/Aes256SivTests.cs
+++ b/test/Pandatech.Crypto.Tests/Aes256SivTests.cs
@@ -1,0 +1,198 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+using Pandatech.Crypto.Helpers;
+using Random = Pandatech.Crypto.Helpers.Random;
+
+namespace Pandatech.Crypto.Tests;
+
+public class Aes256SivTests
+{
+   private static string GenerateRandomAes256KeyString()
+   {
+      return Random.GenerateAes256KeyString();
+   }
+
+   [Fact]
+   public void EncryptDecrypt_ReturnsOriginalString()
+   {
+      // Arrange
+      var key = GenerateRandomAes256KeyString();
+      const string original = "HelloWorld";
+
+      // Act
+      var encrypted = Aes256Siv.Encrypt(original, key);
+      var decrypted = Aes256Siv.Decrypt(encrypted, key);
+
+     
+      Assert.Equal(original, decrypted);
+   }
+
+   [Fact]
+   public void Encrypt_TheSamePlaintextTwice_ProducesSameCiphertext()
+   {
+      // Arrange
+      var key = GenerateRandomAes256KeyString();
+      const string original = "DeterministicTest";
+
+      // Act
+      var cipher1 = Aes256Siv.Encrypt(original, key);
+      var cipher2 = Aes256Siv.Encrypt(original, key);
+
+      // Assert
+      Assert.Equal(cipher1, cipher2);
+   }
+
+   [Fact]
+   public void Encrypt_EmptyPlaintext_ReturnsEmptyCiphertext()
+   {
+      // Arrange
+      var key = GenerateRandomAes256KeyString();
+      var emptyPlaintext = Array.Empty<byte>();
+
+      // Act
+      var result = Aes256Siv.Encrypt(emptyPlaintext, key);
+
+      // Assert
+      Assert.NotNull(result);
+      Assert.Empty(result);
+   }
+
+   [Fact]
+   public void Decrypt_EmptyCiphertext_ReturnsEmptyPlaintext()
+   {
+      // Arrange
+      var key = GenerateRandomAes256KeyString();
+      var emptyCiphertext = Array.Empty<byte>();
+
+      // Act
+      var result = Aes256Siv.DecryptToBytes(emptyCiphertext, key);
+
+      // Assert
+      Assert.NotNull(result);
+      Assert.Empty(result);
+   }
+
+   [Fact]
+   public void Decrypt_CiphertextTooShort_ThrowsArgumentException()
+   {
+      // Arrange
+      var key = GenerateRandomAes256KeyString();
+      var invalidCipher = new byte[10]; // Less than 16 bytes
+
+      // Act & Assert
+      Assert.Throws<ArgumentException>(() => Aes256Siv.Decrypt(invalidCipher, key));
+   }
+
+   [Fact]
+   public void Decrypt_TamperedCiphertext_ThrowsCryptographicException()
+   {
+      // Arrange
+      var key = GenerateRandomAes256KeyString();
+      const string original = "SomeData";
+      var encrypted = Aes256Siv.Encrypt(original, key);
+
+      // Tamper with 1 byte
+      encrypted[5] ^= 0xFF;
+
+      // Act & Assert
+      Assert.Throws<CryptographicException>(() => Aes256Siv.Decrypt(encrypted, key));
+   }
+
+   [Fact]
+   public void EncryptDecrypt_InvalidOverrideKey_ThrowsArgumentException()
+   {
+      // Arrange
+      const string invalidKey = "NotBase64...";
+      const string original = "Test123";
+
+      // Act & Assert
+      Assert.Throws<ArgumentException>(() => Aes256Siv.Encrypt(original, invalidKey));
+   }
+
+   [Fact]
+   public void RegisterKey_ThenEncryptDecrypt_WorksCorrectly()
+   {
+      // Arrange
+      var key = GenerateRandomAes256KeyString();
+      Aes256Siv.RegisterKey(key);
+
+      const string original = "GlobalKeyIsSetNow";
+
+      // Act
+      var encrypted = Aes256Siv.Encrypt(original);
+      var decrypted = Aes256Siv.Decrypt(encrypted);
+
+      // Assert
+      Assert.Equal(original, decrypted);
+   }
+
+   [Fact]
+   public void EncryptDecryptStream_RoundTrip_ReturnsOriginalData()
+   {
+      // Arrange
+      var key = GenerateRandomAes256KeyString();
+      const string original = "StreamingData";
+      using var inputStream = new MemoryStream(Encoding.UTF8.GetBytes(original));
+      using var encryptStream = new MemoryStream();
+      using var decryptStream = new MemoryStream();
+
+      // Act
+      Aes256Siv.Encrypt(inputStream, encryptStream, key);
+
+      // Reset position on the encrypted data
+      encryptStream.Seek(0, SeekOrigin.Begin);
+
+      Aes256Siv.Decrypt(encryptStream, decryptStream, key);
+      decryptStream.Seek(0, SeekOrigin.Begin);
+
+      var decryptedText = new StreamReader(decryptStream).ReadToEnd();
+
+      // Assert
+      Assert.Equal(original, decryptedText);
+   }
+
+   [Fact]
+   public void EncryptDecryptStream_EmptyContent_ProducesEmptyContent()
+   {
+      // Arrange
+      var key = GenerateRandomAes256KeyString();
+      using var emptyInput = new MemoryStream();
+      using var encryptStream = new MemoryStream();
+      using var decryptStream = new MemoryStream();
+
+      // Act
+      Aes256Siv.Encrypt(emptyInput, encryptStream, key);
+      encryptStream.Seek(0, SeekOrigin.Begin);
+
+      Aes256Siv.Decrypt(encryptStream, decryptStream, key);
+      decryptStream.Seek(0, SeekOrigin.Begin);
+
+      // Assert
+      var decryptedText = new StreamReader(decryptStream).ReadToEnd();
+      Assert.Empty(decryptedText);
+   }
+
+   [Fact]
+   public void EncryptStream_InvalidKey_ThrowsArgumentException()
+   {
+      // Arrange
+      const string invalidKey = "NotBase64!";
+      var data = new MemoryStream("Some stream data"u8.ToArray());
+      var output = new MemoryStream();
+
+      // Act & Assert
+      Assert.Throws<ArgumentException>(() => Aes256Siv.Encrypt(data, output, invalidKey));
+   }
+
+   [Fact]
+   public void DecryptStream_InvalidKey_ThrowsArgumentException()
+   {
+      // Arrange
+      const string invalidKey = "NotBase64!";
+      using var input = new MemoryStream([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+      using var output = new MemoryStream();
+
+      // Act & Assert
+      Assert.Throws<ArgumentException>(() => Aes256Siv.Decrypt(input, output, invalidKey));
+   }
+}

--- a/test/Pandatech.Crypto.Tests/AesMigrationTests.cs
+++ b/test/Pandatech.Crypto.Tests/AesMigrationTests.cs
@@ -1,0 +1,154 @@
+﻿using Pandatech.Crypto.Helpers;
+using Random = Pandatech.Crypto.Helpers.Random;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace Pandatech.Crypto.Tests;
+
+public class AesMigrationTests
+{
+   public AesMigrationTests()
+   {
+      var key = Random.GenerateAes256KeyString();
+      Aes256.RegisterKey(key);
+      Aes256Siv.RegisterKey(key);
+   }
+
+   [Fact]
+   public void MigrateFromOldHashed_SingleItem_RoundTrip()
+   {
+      const string originalText = "Hello Hashed World";
+      // Old encryption (with hash)
+      var oldCiphertext = Aes256.Encrypt(originalText);
+
+      // Migrate (decrypt old => encrypt new)
+      var newCiphertext = AesMigration.MigrateFromOldHashed(oldCiphertext);
+
+      // Decrypt new ciphertext with SIV
+      var decrypted = Aes256Siv.Decrypt(newCiphertext);
+      Assert.Equal(originalText, decrypted);
+   }
+
+   [Fact]
+   public void MigrateFromOldNonHashed_SingleItem_RoundTrip()
+   {
+      const string originalText = "Hello Non-Hashed World";
+      // Old encryption (without hash)
+      var oldCiphertext = Aes256.EncryptWithoutHash(originalText);
+
+      // Migrate
+      var newCiphertext = AesMigration.MigrateFromOldNonHashed(oldCiphertext);
+
+      // Decrypt new ciphertext with SIV
+      var decrypted = Aes256Siv.Decrypt(newCiphertext);
+      Assert.Equal(originalText, decrypted);
+   }
+
+   [Fact]
+   public void MigrateFromOldHashedNullable_NullInput_ReturnsNull()
+   {
+      byte[]? nullInput = null;
+      var result = AesMigration.MigrateFromOldHashedNullable(nullInput);
+      Assert.Null(result);
+   }
+
+   [Fact]
+   public void MigrateFromOldNonHashedNullable_NullInput_ReturnsNull()
+   {
+      byte[]? nullInput = null;
+      var result = AesMigration.MigrateFromOldNonHashedNullable(nullInput);
+      Assert.Null(result);
+   }
+
+   [Fact]
+   public void MigrateFromOldHashed_Collection_RoundTrip()
+   {
+      var plaintexts = new[]
+      {
+         "One",
+         "Two",
+         "Three"
+      };
+      var oldCipherList = plaintexts
+                          .Select(Aes256.Encrypt) // Old hashed
+                          .ToList();
+
+      var newCipherList = AesMigration.MigrateFromOldHashed(oldCipherList);
+
+      var decryptedList = newCipherList
+                          .Select(nc => Aes256Siv.Decrypt(nc))
+                          .ToArray();
+
+      for (var i = 0; i < plaintexts.Length; i++)
+      {
+         Assert.Equal(plaintexts[i], decryptedList[i]);
+      }
+   }
+
+   [Fact]
+   public void MigrateFromOldNonHashed_Collection_RoundTrip()
+   {
+      var plaintexts = new[]
+      {
+         "Alpha",
+         "Beta",
+         "Gamma"
+      };
+      var oldCipherList = plaintexts
+                          .Select(Aes256.EncryptWithoutHash) // Old non-hashed
+                          .ToList();
+
+      var newCipherList = AesMigration.MigrateFromOldNonHashed(oldCipherList);
+
+      var decryptedList = newCipherList
+                          .Select(nc => Aes256Siv.Decrypt(nc))
+                          .ToArray();
+
+      Assert.Equal(plaintexts, decryptedList);
+   }
+
+   [Fact]
+   public void MigrateFromOldHashedNullable_CollectionWithNulls_RoundTrip()
+   {
+      var plaintexts = new[]
+      {
+         "First",
+         null,
+         "Second"
+      };
+      // Old hashed ciphertext plus a null
+      var oldCipherList = plaintexts
+                          .Select(pt => pt == null ? null : Aes256.Encrypt(pt))
+                          .ToList();
+
+      var newCipherList = AesMigration.MigrateFromOldHashedNullable(oldCipherList);
+
+      var decryptedList = newCipherList
+                          .Select(nc => nc == null ? null : Aes256Siv.Decrypt(nc))
+                          .ToArray();
+
+      Assert.Equal(plaintexts, decryptedList);
+   }
+
+   [Fact]
+   public void MigrateFromOldNonHashedNullable_CollectionWithNulls_RoundTrip()
+   {
+      var plaintexts = new[]
+      {
+         "X",
+         null,
+         "Y"
+      };
+      var oldCipherList = plaintexts
+                          .Select(pt => pt == null ? null : Aes256.EncryptWithoutHash(pt))
+                          .ToList();
+
+      var newCipherList = AesMigration.MigrateFromOldNonHashedNullable(oldCipherList);
+
+      var decryptedList = newCipherList
+                          .Select(nc => nc == null ? null : Aes256Siv.Decrypt(nc))
+                          .ToArray();
+
+      Assert.Equal(plaintexts, decryptedList);
+   }
+}


### PR DESCRIPTION
…tic and authenticated encryption. The old Aes256 class is deprecated due to security concerns, and the new AesMigration class helps convert existing Aes256 ciphertext to the AES-SIV format. The readme has been updated with code samples and usage recommendations.